### PR TITLE
Enhance error message

### DIFF
--- a/src/main/java/io/jenkins/plugins/eggplant/exception/InvalidRunnerException.java
+++ b/src/main/java/io/jenkins/plugins/eggplant/exception/InvalidRunnerException.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.eggplant.exception;
 import hudson.AbortException;
 
 public class InvalidRunnerException extends AbortException {
-  public InvalidRunnerException(String message, String path) {
-    super(message + ". Eggplant Runner Path: " + path);
+  public InvalidRunnerException(String message) {
+    super(message);
   }
 }

--- a/src/main/java/io/jenkins/plugins/eggplant/utils/CLIRunnerHelper.java
+++ b/src/main/java/io/jenkins/plugins/eggplant/utils/CLIRunnerHelper.java
@@ -49,6 +49,10 @@ public class CLIRunnerHelper{
     return cliFilename;
   }
 
+  public String getPublicDownloadLink(){
+    return CLI_DOWNLOAD_URL.replace("${cliFilename}", cliFilename); 
+  }
+
   public void copyRunnerFrom(String path) throws IOException, InterruptedException
   {
     logger.println(">> Checking runner...");
@@ -65,19 +69,25 @@ public class CLIRunnerHelper{
     {
       /* if the file does not exist, read access would be denied because the Java virtual machine has 
       insufficient privileges, or access cannot be determined */
-      throw new InvalidRunnerException("No such file or permission denied", path);
+      throw new InvalidRunnerException("No such file or permission denied. Eggplant Runner Path: " + path);
+    }
+
+    if(file.isDirectory() == true)
+    {
+      throw new InvalidRunnerException("Path provided must not be a directory. Eggplant Runner Path: " + path);
     }
 
     FilePath filePath = new FilePath(file);
+
     if(!filePath.getName().equals(cliFilename))
     {
-      throw new InvalidRunnerException("Mismatch of version/file.Eggplant runner version supported: '" + cliFilename + "'", path);
+      throw new InvalidRunnerException("File found is invalid. Required: " + cliFilename + ". Please download from " +  getPublicDownloadLink());
     }
     return filePath;
   }
 
   public void downloadRunner(String gitlabAccessToken) throws IOException, InterruptedException{
-    String cliDownloadUrl = CLI_DOWNLOAD_URL.replace("${cliFilename}", cliFilename);   
+    String cliDownloadUrl = getPublicDownloadLink();   
     Map<String,String> properties = new HashMap<>();
 
     logger.println(">> Downloading runner...");

--- a/src/test/java/io/jenkins/plugins/eggplant/utils/CLIRunnerHelperTest.java
+++ b/src/test/java/io/jenkins/plugins/eggplant/utils/CLIRunnerHelperTest.java
@@ -75,7 +75,7 @@ public class CLIRunnerHelperTest {
             Files.createFile(filepath);
             helper.copyRunnerFrom(filepath.toString());
             });
-        assertTrue(thrown.getMessage().contains("Mismatch of version/file.Eggplant runner version supported: '"+helper.getFilename()+"'"));
+        assertTrue(thrown.getMessage().contains("File found is invalid. Required: "+helper.getFilename()+". Please download from " + helper.getPublicDownloadLink()));
         
         // path exist and valid
         Path cliPath = userPath.resolve(helper.getFilename());


### PR DESCRIPTION
Add fix for https://siteconfidence.atlassian.net/browse/ADT-344

Changes:
- Added error message handling when directory is provided as eggplant runner path
- Added download link to error message when filename mismatch

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
