### PR TITLE
Adt 533 client secret mask issue

### DIFF
--- a/src/main/resources/io/jenkins/plugins/eggplant/EggplantRunnerBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/eggplant/EggplantRunnerBuilder/config.jelly
@@ -18,27 +18,39 @@
     </f:entry>
     <f:entry title="Client Secret *" field="clientSecret">
         <f:textbox default="DAI-Client-Secret" id="clientSecret"/>
-        <input type="checkbox" onclick="showPassword()" />Show client secret in text
-        <iframe onload="showPassword()" style="display:none" />
+        <input type="checkbox" onclick="showPassword()" id="ckBox"/>Show client secret in text
+        <iframe onload="doNotShowPassword()" style="display:none" />
         <br/>
         <script>
             function showPassword() {
-            var x = document.getElementById("clientSecret");
-            if (x.type === "password") {
-                x.type = "text";
-            } else {
-                x.type = "password";
-            }
+                document.querySelectorAll('*').forEach(function(node) {
+                    if(node.id==="clientSecret"){
+                        if(node.type ==="password"){
+                            node.type = "text";
+                        }
+                        else
+                        {
+                            node.type = "password";
+                        }
+                    };
+                    if(node.id==="ckBox"){
+                        if (document.getElementById("clientSecret").type === "password"){
+                            node.checked = false;
+                        }
+                        else{
+                            node.checked = true;
+                        }
+                    }
+                });
             }
         </script>
         <script>
-            var x = document.getElementById('clientSecret');
-            if (x != null) {
-                if (x.type === "password") {
-                    x.type = "text";
-                } else {
-                    x.type = "password";
-                }
+            function doNotShowPassword(){
+                document.querySelectorAll('*').forEach(function(node) {
+                    if(node.id==="clientSecret"){
+                        node.type = "password";
+                    }
+                });
             }
         </script>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
This MR is to resolve client secret unable to be masked for sub-sequence build steps onwards.

The resolution of the issue:
- All added build steps are able to mask the Client secret
- Checkbox for each of the build step will perform "check" & "un-check" for all build step
     - If click on any of the checkbox, all build step's client secret will response. Example, if click uncheck on one of the check box in the build step, all build step's checkbox will be unchecked.